### PR TITLE
fix: preserve A/B variants in smartlead duplicate command

### DIFF
--- a/openkiln/skills/smartlead/SKILL.md
+++ b/openkiln/skills/smartlead/SKILL.md
@@ -95,7 +95,11 @@ openkiln smartlead delete <campaign_id>
     "seq_number": 1,
     "seq_delay_details": {"delay_in_days": 0},
     "subject": "Hello {{first_name}}",
-    "email_body": "<div>Your email body here</div>"
+    "email_body": "<div>Your email body here</div>",
+    "seq_variants": [
+      {"subject": "Variant A", "email_body": "<div>A body</div>", "variant_label": "A"},
+      {"subject": "Variant B", "email_body": "<div>B body</div>", "variant_label": "B"}
+    ]
   },
   {
     "seq_number": 2,
@@ -105,6 +109,13 @@ openkiln smartlead delete <campaign_id>
   }
 ]
 ```
+
+A/B testing: add `seq_variants` to any step. Each variant needs
+`subject`, `email_body`, and `variant_label` (A, B, C, etc.).
+A top-level `subject` and `email_body` are still required alongside
+variants. Steps without `seq_variants` use subject/email_body directly.
+
+The `duplicate` command preserves all variants when copying campaigns.
 
 ## Pushing contacts
 

--- a/openkiln/skills/smartlead/cli.py
+++ b/openkiln/skills/smartlead/cli.py
@@ -419,11 +419,22 @@ def duplicate(
                     "seq_number": seq.get("seq_number"),
                     "seq_delay_details": {"delay_in_days": delay_days},
                 }
-                # copy subject/body from top-level or first variant
+                # copy variants if present, otherwise fall back to top-level subject/body
                 variants = seq.get("sequence_variants", [])
                 if variants:
-                    entry["subject"] = variants[0].get("subject", "")
-                    entry["email_body"] = variants[0].get("email_body", "")
+                    active_variants = [v for v in variants if not v.get("is_deleted")]
+                    entry["seq_variants"] = [
+                        {
+                            "subject": v.get("subject", ""),
+                            "email_body": v.get("email_body", ""),
+                            "variant_label": v.get("variant_label", ""),
+                        }
+                        for v in active_variants
+                    ]
+                    # API also needs top-level subject/body
+                    first = active_variants[0] if active_variants else {}
+                    entry["subject"] = first.get("subject", "")
+                    entry["email_body"] = first.get("email_body", "")
                 elif seq.get("subject"):
                     entry["subject"] = seq.get("subject", "")
                     entry["email_body"] = seq.get("email_body", "")
@@ -493,11 +504,17 @@ def sequence(
       {
         "seq_number": 1,
         "seq_delay_details": {"delay_in_days": 0},
-        "variants": [
-          {"subject": "...", "email_body": "...", "variant_label": "A"}
+        "subject": "Default subject",
+        "email_body": "<div>Default body</div>",
+        "seq_variants": [
+          {"subject": "Variant A subject", "email_body": "<div>...</div>", "variant_label": "A"},
+          {"subject": "Variant B subject", "email_body": "<div>...</div>", "variant_label": "B"}
         ]
       }
     ]
+
+    Steps without seq_variants use subject/email_body directly.
+    Steps with seq_variants also need a top-level subject/email_body (used as fallback).
     """
     content = file.read_text()
 


### PR DESCRIPTION
## Summary
- `duplicate` command now preserves all A/B test variants when copying campaigns, instead of only copying the first variant's subject/body
- CLI docstring corrected from `variants` to `seq_variants` (matching the Smartlead API field name)
- SKILL.md updated with `seq_variants` format and A/B testing documentation

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] All 16 smartlead tests pass (1 pre-existing failure in `test_api_client_no_key_error` — tracked in #1)
- [x] Manually verified: created campaign 3133669 with 3 variants via `seq_variants`, confirmed all 3 saved correctly via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)