### PR TITLE
fix: map track_settings values between GET and POST formats

### DIFF
--- a/openkiln/skills/smartlead/SKILL.md
+++ b/openkiln/skills/smartlead/SKILL.md
@@ -82,7 +82,8 @@ openkiln smartlead schedule <campaign_id> \
   --days 1,2,3,4,5 \
   --start-hour "09:00" \
   --end-hour "17:00" \
-  --max-leads-per-day 50
+  --max-leads-per-day 50 \
+  --min-gap 35
 
 # delete a campaign
 openkiln smartlead delete <campaign_id>

--- a/openkiln/skills/smartlead/api.py
+++ b/openkiln/skills/smartlead/api.py
@@ -275,9 +275,25 @@ class SmartleadClient:
             body["max_new_leads_per_day"] = max_leads_per_day
         return self._post(f"/campaigns/{campaign_id}/schedule", body)
 
+    # GET returns DONT_EMAIL_OPEN / DONT_LINK_CLICK but POST requires
+    # DONT_TRACK_EMAIL_OPEN / DONT_TRACK_LINK_CLICK.
+    _TRACK_SETTINGS_WRITE_MAP: dict[str, str] = {
+        "DONT_EMAIL_OPEN": "DONT_TRACK_EMAIL_OPEN",
+        "DONT_LINK_CLICK": "DONT_TRACK_LINK_CLICK",
+    }
+
     def update_campaign_settings(self, campaign_id: int, settings: dict) -> Any:
-        """Update campaign settings (track_settings, stop_lead_settings, etc)."""
-        return self._post(f"/campaigns/{campaign_id}/settings", settings)
+        """Update campaign settings (track_settings, stop_lead_settings, etc).
+
+        Automatically maps track_settings values from the GET format
+        to the POST format expected by the API.
+        """
+        body = dict(settings)
+        if "track_settings" in body and isinstance(body["track_settings"], list):
+            body["track_settings"] = [
+                self._TRACK_SETTINGS_WRITE_MAP.get(v, v) for v in body["track_settings"]
+            ]
+        return self._post(f"/campaigns/{campaign_id}/settings", body)
 
     def delete_campaign(self, campaign_id: int) -> Any:
         """Delete a campaign."""


### PR DESCRIPTION
## Summary
- Smartlead API returns `DONT_EMAIL_OPEN` / `DONT_LINK_CLICK` in GET responses but requires `DONT_TRACK_EMAIL_OPEN` / `DONT_TRACK_LINK_CLICK` in POST requests
- `update_campaign_settings` now auto-maps these values so callers can pass either format
- Added `--min-gap` to the schedule example in SKILL.md

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] All 16 smartlead tests pass (1 pre-existing failure excluded — #1)
- [x] Manually verified: settings with mapped values accepted by Smartlead API

🤖 Generated with [Claude Code](https://claude.com/claude-code)